### PR TITLE
Update scripts and add factory root password

### DIFF
--- a/scripts/11_ssh_keys.sh
+++ b/scripts/11_ssh_keys.sh
@@ -2,3 +2,4 @@
 
 echo "[*] Adding symlink to ssh-keys in data"
 ln -vsf /data/ssh $ROOTFS/root/.ssh
+#ln -vsf /data/ssh $ROOTFS/etc/dropbear

--- a/scripts/12_root_password_factory.sh
+++ b/scripts/12_root_password_factory.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "[*] Replacing factory default root password"
+# in case that /data partition is not mounted, this will allow you to login.
+# NOTE: Remember to set a custom password after flashing!
+
+# password: root
+HASH='$5$xiaoai$sry7iaqDMu/y7/yz5w1BcV26l2RGFBd6WHXiuLahL9D'
+
+sed -i 's,^\(root:\)[^:]*\(:.*\)$,\1'"${HASH}"'\2,' $ROOTFS/etc/shadow
+
+# show result
+grep "root:" $ROOTFS/etc/shadow

--- a/scripts/12_root_password_factory.sh
+++ b/scripts/12_root_password_factory.sh
@@ -5,6 +5,7 @@ echo "[*] Replacing factory default root password"
 # NOTE: Remember to set a custom password after flashing!
 
 # password: root
+# openssl passwd -5 -salt xiaoai root
 HASH='$5$xiaoai$sry7iaqDMu/y7/yz5w1BcV26l2RGFBd6WHXiuLahL9D'
 
 sed -i 's,^\(root:\)[^:]*\(:.*\)$,\1'"${HASH}"'\2,' $ROOTFS/etc/shadow

--- a/scripts/21_patch_service_bluetooth.sh
+++ b/scripts/21_patch_service_bluetooth.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 
+AMOUNT=0
 FILE=$ROOTFS/etc/init.d/check_mac
 SHA=$(shasum $FILE | awk '{print $1}')
 if [ "$SHA" = "ee8e4573719da3defd72de263283524c132f3a7f" ]; then
@@ -9,6 +10,7 @@ if [ "$SHA" = "ee8e4573719da3defd72de263283524c132f3a7f" ]; then
   sed -i '36,39d' $FILE  # delete data bt_config.xml
   sed -i '90d' $FILE     # replace bd_name
   sed -i '93d' $FILE     # replace bt_name
+  AMOUNT=$(( $AMOUNT + 1 ))
 fi
 shasum $FILE
 
@@ -20,15 +22,21 @@ if [ "$SHA" = "f51dabcac09d6815356b85e43aab9884a36965a4" ]; then
 
   # new bluealsa params, fix start
   sed -i 's/"$PROG2".*/"$PROG2" 00:00:00:00:00:00 -v -D bluetooth --profile-a2dp/' $FILE
+  AMOUNT=$(( $AMOUNT + 1 ))
 fi
 shasum $FILE
 
 FILE=$ROOTFS/etc/init.d/bluetoothd
-SHA=$(shasum $FILE | awk '{print $1}')
+if [ -f "${FILE}" ]; then
+  SHA=$(shasum $FILE | awk '{print $1}')
 
-echo "[*] Patching Bluetoothd start service"
-# add parameter to load config from writable flash, not readonly memory
-# so this way user can customize bluetooth name and params
-sed -i 's;command "$PROG".*;command "$PROG" -n -f $conf_dir/bluetooth/main.conf;' $FILE
+  echo "[*] Patching Bluetoothd start service"
+  # add parameter to load config from writable flash, not readonly memory
+  # so this way user can customize bluetooth name and params
+  sed -i 's;command "$PROG".*;command "$PROG" -n -f $conf_dir/bluetooth/main.conf;' $FILE
+  AMOUNT=$(( $AMOUNT + 1 ))
+fi
 
 shasum $FILE
+
+echo "[*] ${AMOUNT} patches applied"

--- a/scripts/91_add_shell_bash.sh
+++ b/scripts/91_add_shell_bash.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-echo "[*] Enabling /bin/bash as shell"
-echo "/bin/bash" >> $ROOTFS/etc/shells

--- a/scripts/95_add_shell_bash.sh
+++ b/scripts/95_add_shell_bash.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+FILE=/bin/bash
+
+if [ -f "${ROOTFS}${FILE}" ]; then
+  echo "[*] Enabling ${FILE} as shell"
+  echo "${FILE}" >> $ROOTFS/etc/shells
+fi

--- a/scripts/95_add_shell_bash.sh
+++ b/scripts/95_add_shell_bash.sh
@@ -2,6 +2,11 @@
 
 FILE=/bin/bash
 
+if [ -f "${ROOTFS}/usr${FILE}" ] && [ ! -e "${ROOTFS}${FILE}" ]; then
+  echo "[*] Adding symlink for bash"
+  ln -svf /usr${FILE} ${ROOTFS}${FILE}
+fi
+
 if [ -f "${ROOTFS}${FILE}" ]; then
   echo "[*] Enabling ${FILE} as shell"
   echo "${FILE}" >> $ROOTFS/etc/shells


### PR DESCRIPTION
Due to recently being locked because doing things quick (testing new firmware),
I'm setting a default factory **root** password to avoid this happening again ever.

If script continues mounting custom password from `/data` this won't even affect you.

Also - improving `/bin/bash` shell.