### PR TITLE
fix(ci): release package metadata invalid

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -10,10 +10,12 @@ on:
   push:
     tags:
       - '*.*.*'
+  pull_request:
 
 jobs:
   packages:
     name: Packages
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -24,7 +26,7 @@ jobs:
 
   image:
     name: Image
-    needs: [packages]
+    #needs: [packages]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,6 +34,8 @@ jobs:
         model: [lx01, lx06, l09a, l09b]
     env:
       MODEL: ${{ matrix.model }}
+      PULL_PACKAGES: false
+      UPLOAD_RELEASE: false
     steps:
       - uses: actions/checkout@v4
 
@@ -69,11 +73,13 @@ jobs:
 
       - name: Pull build packages
         uses: actions/download-artifact@v4
+        if: ${{ env.PULL_PACKAGES == 'true' }}
         with:
           name: build-${{ matrix.model }}
           path: build-packages/targets/
 
       - name: Extract build packages
+        if: ${{ env.PULL_PACKAGES == 'true' }}
         env:
           SOURCE_DIR: build-packages/targets
           TARGET: build-packages/s2t/armv7
@@ -112,10 +118,17 @@ jobs:
           } >> ${GITHUB_STEP_SUMMARY}
 
       - name: Upload artifact to release
+        if: ${{ env.UPLOAD_RELEASE == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.artifact.outputs.name }}
           draft: true
+
+      - name: Upload artifact to Workflow Run
+        if: ${{ env.UPLOAD_RELEASE == 'false' }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ steps.artifact.outputs.name }}
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -128,7 +128,10 @@ jobs:
         if: ${{ env.UPLOAD_RELEASE == 'false' }}
         uses: actions/upload-artifact@v4
         with:
+          name: ${{ steps.artifact.outputs.name }}
           path: ${{ steps.artifact.outputs.name }}
+          retention-days: 10
+          if-no-files-found: error
 
       - name: Attest Build Provenance
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -88,7 +88,7 @@ jobs:
           sudo tar xzvf ${SOURCE_DIR}/bin-*.tar.gz -C ${TARGET}
 
       - name: Build artifact
-        run: sudo make patch build release MODEL=${MODEL}
+        run: sudo -E make patch build release MODEL=${MODEL}
 
       - name: Prepare artifact
         id: artifact

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,12 @@ release_set_config:
 	mkdir -p $(RELEASE_DIR)
 	@cp -vf $(MICO_VERSION) $(RELEASE_DIR)/metadata
 	@IMAGE_MD5=$(shell md5sum $(DESTDIR)/$(IMAGE_NAME) | cut -d ' ' -f 1); \
+	echo "" >> $(RELEASE_DIR)/metadata; \
 	echo "config core 'hash'" >> $(RELEASE_DIR)/metadata; \
-	echo -e "\toption ROOTFS '$$IMAGE_MD5'" >> $(RELEASE_DIR)/metadata
+	printf "\toption ROOTFS '%s'" "$$IMAGE_MD5" >> $(RELEASE_DIR)/metadata
 ifneq ($(LINUX),none)
 	@LINUX_MD5=$(shell md5sum $(LINUX) | cut -d ' ' -f 1); \
-	echo -e "\toption LINUX '$$LINUX_MD5'" >> $(RELEASE_DIR)/metadata
+	printf "\toption LINUX '%s'" "$$LINUX_MD5" >> $(RELEASE_DIR)/metadata
 endif
 
 release_pack:

--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,10 @@ release_set_config:
 	@IMAGE_MD5=$(shell md5sum $(DESTDIR)/$(IMAGE_NAME) | cut -d ' ' -f 1); \
 	echo "" >> $(RELEASE_DIR)/metadata; \
 	echo "config core 'hash'" >> $(RELEASE_DIR)/metadata; \
-	printf "\toption ROOTFS '%s'" "$$IMAGE_MD5" >> $(RELEASE_DIR)/metadata
+	printf "\toption ROOTFS '%s'\n" "$$IMAGE_MD5" >> $(RELEASE_DIR)/metadata
 ifneq ($(LINUX),none)
 	@LINUX_MD5=$(shell md5sum $(LINUX) | cut -d ' ' -f 1); \
-	printf "\toption LINUX '%s'" "$$LINUX_MD5" >> $(RELEASE_DIR)/metadata
+	printf "\toption LINUX '%s'\n" "$$LINUX_MD5" >> $(RELEASE_DIR)/metadata
 endif
 
 release_pack:


### PR DESCRIPTION
* fix invalid `metadata` generated ( echo `-e` inside of the file)
* fix channel `release` for builds in GHA (`GITHUB_ACTIONS` env not preserved by `sudo`)