### PR TITLE
fix(libgcrypt): update getentropy for old Linux devices

### DIFF
--- a/packages/libgcrypt/package.mk
+++ b/packages/libgcrypt/package.mk
@@ -6,12 +6,18 @@ PACKAGE_SRC="https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${PACKAGE_VERS
 
 configure_package() {
 	# LX01 and S12 do not support the getentropy function (kernel version too low).
+	# This affects shairport-sync AirPlay2 feature, issue #97
 	EXTRA_FLAGS=""
 	if [ "$BUILD_MODEL" = "LX01" ] || [ "$BUILD_MODEL" = "S12" ]; then
 	    EXTRA_FLAGS="--enable-random=linux"
 	fi
 	
-	CC="${BUILD_CC}" CXX="${BUILD_CXX}" CFLAGS="${BUILD_CFLAGS}" CXXFLAGS="${BUILD_CFLAGS}" CPPFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}" PKG_CONFIG_LIBDIR="${BUILD_PKG_CONFIG_LIBDIR}" PKG_CONFIG_SYSROOT_DIR="${BUILD_PKG_CONFIG_SYSROOT_DIR}" ./configure --prefix=${INSTALL_PREFIX} --build=${MACHTYPE} --host=${BUILD_TARGET} --with-libgpg-error-prefix=${STAGING_DIR}/${INSTALL_PREFIX} ${EXTRA_FLAGS}
+	CC="${BUILD_CC}" CXX="${BUILD_CXX}" CFLAGS="${BUILD_CFLAGS}" \
+		 CXXFLAGS="${BUILD_CFLAGS}" CPPFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}" \
+		 PKG_CONFIG_LIBDIR="${BUILD_PKG_CONFIG_LIBDIR}" PKG_CONFIG_SYSROOT_DIR="${BUILD_PKG_CONFIG_SYSROOT_DIR}" \
+		 ./configure --prefix=${INSTALL_PREFIX} --build=${MACHTYPE} --host=${BUILD_TARGET} \
+		 --with-libgpg-error-prefix=${STAGING_DIR}/${INSTALL_PREFIX} \
+		 ${EXTRA_FLAGS}
 }
 
 make_package() {

--- a/packages/libgcrypt/package.mk
+++ b/packages/libgcrypt/package.mk
@@ -5,7 +5,13 @@ PACKAGE_SRC="https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-${PACKAGE_VERS
 
 
 configure_package() {
-	CC="${BUILD_CC}" CXX="${BUILD_CXX}" CFLAGS="${BUILD_CFLAGS}" CXXFLAGS="${BUILD_CFLAGS}" CPPFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}" PKG_CONFIG_LIBDIR="${BUILD_PKG_CONFIG_LIBDIR}" PKG_CONFIG_SYSROOT_DIR="${BUILD_PKG_CONFIG_SYSROOT_DIR}" ./configure --prefix=${INSTALL_PREFIX} --build=${MACHTYPE} --host=${BUILD_TARGET} --with-libgpg-error-prefix=${STAGING_DIR}/${INSTALL_PREFIX} ${extra_flags}
+	# LX01 and S12 do not support the getentropy function (kernel version too low).
+	EXTRA_FLAGS=""
+	if [ "$BUILD_MODEL" = "LX01" ] || [ "$BUILD_MODEL" = "S12" ]; then
+	    EXTRA_FLAGS="--enable-random=linux"
+	fi
+	
+	CC="${BUILD_CC}" CXX="${BUILD_CXX}" CFLAGS="${BUILD_CFLAGS}" CXXFLAGS="${BUILD_CFLAGS}" CPPFLAGS="${BUILD_CFLAGS}" LDFLAGS="${BUILD_LDFLAGS}" PKG_CONFIG_LIBDIR="${BUILD_PKG_CONFIG_LIBDIR}" PKG_CONFIG_SYSROOT_DIR="${BUILD_PKG_CONFIG_SYSROOT_DIR}" ./configure --prefix=${INSTALL_PREFIX} --build=${MACHTYPE} --host=${BUILD_TARGET} --with-libgpg-error-prefix=${STAGING_DIR}/${INSTALL_PREFIX} ${EXTRA_FLAGS}
 }
 
 make_package() {


### PR DESCRIPTION
It is not the best solution. The issue might be caused by `glibc` or the toolchain, and it’s possible that other packages may have the same issue.